### PR TITLE
Disable auto correct and auto capitalization on text fields.

### DIFF
--- a/Sources/AutomaticSettings/AutomaticSettingsViewDSL.swift
+++ b/Sources/AutomaticSettings/AutomaticSettingsViewDSL.swift
@@ -149,6 +149,8 @@ public extension AutomaticSettingsViewDSL {
                     sideEffect: sideEffect
                 )
             )
+            .autocapitalization(.none)
+            .disableAutocorrection(true)
             .fixedSize()
         }
     }
@@ -173,6 +175,8 @@ public extension AutomaticSettingsViewDSL {
                     )
                 })
             )
+            .autocapitalization(.none)
+            .disableAutocorrection(true)
             .fixedSize()
         }
     }
@@ -197,6 +201,8 @@ public extension AutomaticSettingsViewDSL {
                     )
                 })
             )
+            .autocapitalization(.none)
+            .disableAutocorrection(true)
             .fixedSize()
         }
     }


### PR DESCRIPTION
This disables autocorrect and auto capitalization on all text fields. I think that's a safe assumption to make here since is more dev focused. But maybe we can make it configurable somehow if you think that's necessary?